### PR TITLE
Assorted patches to Copyright line building

### DIFF
--- a/spdx-data.el
+++ b/spdx-data.el
@@ -9,7 +9,7 @@
 ;;
 ;;; Code:
 
-(defconst spdx-data-release-date "2021-02-14")
+(defconst spdx-data-release-date "2021-02-23")
 
 (defconst spdx-data-license-identifiers
   '(
@@ -324,6 +324,7 @@
     "OFL-1.1-RFN"
     "OFL-1.1-no-RFN"
     "OGC-1.0"
+    "OGDL-Taiwan-1.0"
     "OGL-Canada-2.0"
     "OGL-UK-1.0"
     "OGL-UK-2.0"

--- a/spdx.el
+++ b/spdx.el
@@ -70,8 +70,9 @@
 
 ;;; Code:
 
-(require 'tempo)
 (require 'newcomment)
+(require 'subr-x)
+(require 'tempo)
 
 (require 'spdx-data)
 

--- a/spdx.el
+++ b/spdx.el
@@ -281,4 +281,5 @@ Returns nil if no existing Copyright line is found."
   (tempo-use-tag-list 'spdx-tempo-tags))
 
 (provide 'spdx)
+
 ;;; spdx.el ends here

--- a/spdx.el
+++ b/spdx.el
@@ -6,7 +6,7 @@
 ;; Keywords: license, tools
 ;; URL: https://github.com/condy0919/spdx.el
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/spdx.el
+++ b/spdx.el
@@ -103,9 +103,27 @@ nil means not to use project information."
                  (const :tag "Disable" nil))
   :group 'spdx)
 
+(defun spdx--command-stdout-or-nil (command &rest args)
+  "Internal helper to run an external program.
+
+If COMMAND exists, run it with ARGS. If the program is
+successful, return everything it wrote to standard output as a
+string (trimming whitespace). Otherwise return nil."
+  (let ((command (executable-find command)))
+    (and command
+         (with-temp-buffer
+           (let ((status (apply #'call-process command
+                                nil (current-buffer) nil args)))
+             (and (equal 0 status) (string-trim (buffer-string))))))))
+
+(defun spdx--guess-user-name-from-git ()
+  "Get local or global user name from Git cofiguration."
+  (spdx--command-stdout-or-nil "git" "config" "user.name"))
+
 (defun spdx--guess-user-name ()
   "Guess a user name for the current buffer."
-  user-full-name)
+  (or (spdx--guess-user-name-from-git)
+      user-full-name))
 
 (defun spdx--detect-project-type ()
   "Detect project type for current buffer.

--- a/spdx.el
+++ b/spdx.el
@@ -117,7 +117,7 @@ string (trimming whitespace). Otherwise return nil."
              (and (equal 0 status) (string-trim (buffer-string))))))))
 
 (defun spdx--guess-user-name-from-git ()
-  "Get local or global user name from Git cofiguration."
+  "Get local or global user name from Git configuration."
   (spdx--command-stdout-or-nil "git" "config" "user.name"))
 
 (defun spdx--guess-user-name ()

--- a/spdx.el
+++ b/spdx.el
@@ -114,7 +114,10 @@ string (trimming whitespace). Otherwise return nil."
          (with-temp-buffer
            (let ((status (apply #'call-process command
                                 nil (current-buffer) nil args)))
-             (and (equal 0 status) (string-trim (buffer-string))))))))
+             (and (equal 0 status)
+                  (let ((output (string-trim (buffer-string))))
+                    (and (not (string-blank-p output))
+                         output))))))))
 
 (defun spdx--guess-user-name-from-git ()
   "Get local or global user name from Git configuration."


### PR DESCRIPTION
- Quite a lot of refactoring of the existing code.
- Prefer getting username from Git config, which is more likely to be correct than Emacs `user-full-name`.
- A `spdx-get-existing-copyright` function has now been added, but does not do anything yet (always returns nil).

OK?