### PR TITLE
Rename invalidated variable spdx-copyright-name

### DIFF
--- a/spdx.el
+++ b/spdx.el
@@ -222,7 +222,7 @@ Returns nil if no existing Copyright line is found."
 
 (defun spdx-copyright-format ()
   "Prompt for SPDX Copyright line, with a guess for the default line."
-  (let ((prefix spdx-copyright-name))
+  (let ((prefix spdx-copyright-prefix))
     (concat prefix
             (read-from-minibuffer
              prefix


### PR DESCRIPTION
The customizable variable `spdx-copyright-name` was introduced in commit bd68c0b. It was referenced in function [`spdx-copyright-format`](https://github.com/condy0919/spdx.el/blob/bd68c0bb6958b647f955600c490d395179713cb3/spdx.el#L225).

The variable was renamed as `spdx-copyright-prefix` in commit 5126bc4. However, the corresponding change was not made to the line that references it. This leads to failure of the commands `spdx-insert-copyright` and `spdx-insert-spdx-copyright` with one of the following error messages:

```
tempo-insert: Symbol’s value as variable is void: spdx-copyright-name
```
or
```
Warning (comp): spdx.el:225:17: Warning: reference to free variable ‘spdx-copyright-name’
```

This PR makes the required change to the line that references the variable. I have tested it on my system and confirmed that  both functions work now.

Thanks!